### PR TITLE
增加对nox（夜神）的支持

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,6 +25,8 @@ import win32api
 import win32con
 import win32gui
 import win32ui
+import win32process
+import psutil
 from PIL import Image
 
 from src.images import image_base64
@@ -42,6 +44,7 @@ class IDIMG:
     def __init__(self):
         self.game_times = 0  # 游戏回合数
         self.game_hwnd = 0  # 游戏窗口句柄hwnd
+        self.game_pid = 0 # 游戏进程PID
         self.game_kind = 1  # 游戏类型 | 1:主线及材料 | 2:剿灭
         self.game_ann_kind = 1  # 剿灭种类
         self.game_title = ""  # 模拟器标题
@@ -204,9 +207,11 @@ class IDIMG:
                 self.game_hwnd = eval(
                     input("\033[0;30;47m手动输入hwnd(进程名前的数字):\033[0m"))
                 self.game_title = self.hwnd_title[self.game_hwnd]
-            self.subHandle = win32gui.FindWindowEx(
-                int(self.game_hwnd), 0, None, None)
-            self.game_hwnd = self.subHandle
+            self.game_pid = win32process.GetWindowThreadProcessId(self.game_hwnd)[1]
+            if psutil.Process(self.game_pid).name().lower() != 'nox.exe':
+                self.subHandle = win32gui.FindWindowEx(
+                    int(self.game_hwnd), 0, None, None)
+                self.game_hwnd = self.subHandle
 
         try:
             setHwnd()
@@ -342,6 +347,8 @@ def mouse_click(hwnd, position):
     hwnd = int(hwnd)
     p = win32api.MAKELONG(position[0], position[1])
     win32gui.SendMessage(hwnd, win32con.WM_ACTIVATE, win32con.WA_ACTIVE, 0)
+    win32gui.SendMessage(hwnd, win32con.WM_MOUSEMOVE, 0, p)
+    win32gui.SendMessage(hwnd, win32con.WM_MOUSEHOVER, 0, p)
     win32api.SendMessage(hwnd, win32con.WM_LBUTTONDOWN, win32con.MK_LBUTTON, p)
     sleep(0.1)
     win32api.SendMessage(hwnd, win32con.WM_LBUTTONUP, win32con.MK_LBUTTON, p)


### PR DESCRIPTION
首先膜一下。
我的CPU不支持VT，雷电有点问题就用夜神了。给夜神添加支持要稍微改一点点。我的改动主要有

1. 夜神似乎需要有鼠标移动和hover事件才会完整触发点击，具体两个中间有没有不需要的我没看，反正两个都加上就能用了
2. 夜神没有雷电那样的模拟器主窗口，没有子句柄，所以我加了一个判断规则，窗口句柄对应的进程是`Nox.exe`的时候就不获取子句柄。
3. 我没有雷电所以没测试雷电能不能用。但是理论上是没问题的。
4. 如果你不嫌弃的话就合并一下吧。嫌弃的话自己加上也行。我就想交个朋友，这是我人生中第一个PR。
5. 请多指教。
6. 最后再膜一下。